### PR TITLE
Fix tarpaulin with a new tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,5 @@
 ## `v0.2.0`
 
 - Add `clippy` component into stable and beta.
-- Fix `cargo-tarpaulin` to `v0.6.6` since it is the last version that supported
-  stable release.
+- Install `cargo-tarpaulin` on only `nightly` due to changes in
+  <https://github.com/xd009642/tarpaulin/commit/48dda7b33c614666db27085e1d9aee9ee8df26bb>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## `v0.2.0`
+
+- Add `clippy` component into stable and beta.
+- Fix `cargo-tarpaulin` to `v0.6.6` since it is the last version that supported
+  stable release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ENV CARGO_HOME=/opt/.cargo
 ENV RUSTUP_HOME=/opt/.rustup
 ENV PATH=${CARGO_HOME}/bin:${PATH}
 
+ARG CARGO_TARPAULIN_VERS="0.6.6"
+
 RUN set -x \
     # set up dependencies first
     && apt-get update \
@@ -25,16 +27,17 @@ RUN set -x \
     # rustup set-up (default is stable)
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path \
     --default-toolchain stable \
-    && rustup component add rustfmt-preview \
+    && rustup component add clippy-preview rustfmt-preview \
     # then beta
     && rustup toolchain add beta \
-    && rustup component add --toolchain beta rustfmt-preview \
+    && rustup component add --toolchain beta clippy-preview rustfmt-preview \
     # then nightly
     && rustup toolchain add nightly \
     && rustup component add --toolchain nightly clippy-preview rustfmt-preview \
     # install cargo-tarpaulin via stable
     # see: https://github.com/xd009642/tarpaulin/commit/651be48104c700b76b1ec61b9bb72df1b21cfd8c#diff-04c6e90faac2675aa89e2176d2eec7d8
-    && RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo +stable install cargo-tarpaulin \
+    # see: https://github.com/rust-lang/cargo/issues/6015, publish-lockfile currently requires nightly, so we fix the version for now
+    && RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo +stable install cargo-tarpaulin --vers "=${CARGO_TARPAULIN_VERS}" \
     # install diesel_cli via stable
     && cargo +stable install diesel_cli \
     # clean-up

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ENV CARGO_HOME=/opt/.cargo
 ENV RUSTUP_HOME=/opt/.rustup
 ENV PATH=${CARGO_HOME}/bin:${PATH}
 
-ARG CARGO_TARPAULIN_VERS="0.6.6"
-
 RUN set -x \
     # set up dependencies first
     && apt-get update \
@@ -36,8 +34,8 @@ RUN set -x \
     && rustup component add --toolchain nightly clippy-preview rustfmt-preview \
     # install cargo-tarpaulin via stable
     # see: https://github.com/xd009642/tarpaulin/commit/651be48104c700b76b1ec61b9bb72df1b21cfd8c#diff-04c6e90faac2675aa89e2176d2eec7d8
-    # see: https://github.com/rust-lang/cargo/issues/6015, publish-lockfile currently requires nightly, so we fix the version for now
-    && RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo +stable install cargo-tarpaulin --vers "=${CARGO_TARPAULIN_VERS}" \
+    # see: https://github.com/rust-lang/cargo/issues/6015
+    && cargo +nightly install cargo-tarpaulin \
     # install diesel_cli via stable
     && cargo +stable install diesel_cli \
     # clean-up

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ See [CHANGELOG](CHANGELOG.md).
   - `cargo clippy`
   - `cargo +beta clippy`
   - `cargo +nightly clippy`
-- `cargo tarpaulin` via stable <https://github.com/xd009642/tarpaulin>
-  - Installed via `cargo install cargo-tarpaulin`
-  - `cargo tarpaulin`
+- `cargo tarpaulin` via nightly only <https://github.com/xd009642/tarpaulin>
+  - Installed via `cargo +nightly install cargo-tarpaulin`
+  - `cargo +nightly tarpaulin`
 - `diesel` via stable <https://github.com/diesel-rs/diesel>
   - Installed via `cargo install diesel`
   - `diesel`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Docker Hub link: <https://hub.docker.com/r/guangie88/rs-cider>
 The purpose of the Docker image is to create a "Swiss Army knife" for automated
 CI/CD purposes for Rust environment.
 
+## Changelog
+
+See [CHANGELOG](CHANGELOG.md).
+
 ## Included stuff
 
 - `rustfmt-preview` (`cargo fmt`) on all stable, beta, nightly
@@ -21,10 +25,12 @@ CI/CD purposes for Rust environment.
     - `cargo fmt`
     - `cargo +beta fmt`
     - `cargo +nightly fmt`
-- `cargo clippy` only on nightly
+- `cargo clippy` only on all stable, beta, nightly
   <https://github.com/rust-lang-nursery/rust-clippy>
   - Installed via `rustup component add clippy`
   - `cargo clippy`
+  - `cargo +beta clippy`
+  - `cargo +nightly clippy`
 - `cargo tarpaulin` via stable <https://github.com/xd009642/tarpaulin>
   - Installed via `cargo install cargo-tarpaulin`
   - `cargo tarpaulin`


### PR DESCRIPTION
Also add `clippy` into `stable` and `beta`.